### PR TITLE
Remove Tigramite from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
     "networkx>=2.6.0",
     "matplotlib>=3.4.0",
     "tqdm>=4.60.0",
-    "tigramite>=5.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #20.

Tigramite is only used in tests, so this removes it from the main dependencies and keeps it in the `dev` extra.

Verified that:
- normal installation works without Tigramite
- `.[dev]` still includes Tigramite
- no new test failures were introduced