### PR TITLE
Fix NumPy and Matplotlib compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         exclude:
           # Reduce matrix size - test fewer combinations on Windows/Mac
           - os: windows-latest
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -47,6 +47,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+
+    - name: Install and verify NumPy 2.x
+      if: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13' }}
+      run: |
+        python -m pip install "numpy>=2"
+        python -c "import numpy as np; major = int(np.__version__.split('.', 1)[0]); print('numpy', np.__version__); raise SystemExit(0 if major >= 2 else 1)"
 
     - name: List installed packages
       run: pip list

--- a/causationentropy/core/plotting.py
+++ b/causationentropy/core/plotting.py
@@ -518,7 +518,7 @@ def plot_causal_network(
         )
 
         # Get colors from colormap
-        cmap = plt.cm.get_cmap(colormaps[i % len(colormaps)])
+        cmap = plt.get_cmap(colormaps[i % len(colormaps)])
         colors = cmap(norm_cmis)
 
         # Modulate alpha by p-value if requested
@@ -562,7 +562,7 @@ def plot_causal_network(
     # Create legend for lag groups
     legend_elements = []
     for i, lag in enumerate(sorted_lags):
-        colormap = plt.cm.get_cmap(colormaps[i % len(colormaps)])
+        colormap = plt.get_cmap(colormaps[i % len(colormaps)])
         color = colormap(0.7)
         legend_elements.append(
             Patch(facecolor=color, edgecolor="black", label=f"Lag {lag}")
@@ -581,7 +581,7 @@ def plot_causal_network(
     # Add colorbar showing CMI scale if requested
     if show_colorbar and sorted_lags:
         # Create colorbar for the first lag as representative
-        cmap = plt.cm.get_cmap(colormaps[0])
+        cmap = plt.get_cmap(colormaps[0])
         sm = plt.cm.ScalarMappable(
             cmap=cmap, norm=Normalize(vmin=0, vmax=global_max_cmi)
         )

--- a/causationentropy/core/stats.py
+++ b/causationentropy/core/stats.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.integrate import trapezoid
 
 
 def auc(TPRs, FPRs):
@@ -72,11 +73,7 @@ def auc(TPRs, FPRs):
     >>> print(f"Random AUC: {auc(tpr_random, fpr_random)}")
     """
 
-    # Use trapezoid for NumPy 2.0+, trapz for older versions
-    if hasattr(np, "trapezoid"):
-        AUC = np.trapezoid(TPRs, FPRs)
-    else:
-        AUC = np.trapz(TPRs, FPRs)
+    AUC = trapezoid(TPRs, FPRs)
     return AUC
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
Fixes #13.

This updates deprecated NumPy and Matplotlib API usage for compatibility with newer versions, and adds Python 3.12/3.13 + NumPy 2.x coverage to CI.

Before -> the test suite had 22 failing plotting tests

Local test result after the fix:
381 passed, 17 deselected.